### PR TITLE
[RFR] Fixed administracion_effictivo on windows by forcing UTF-8 encoding usage

### DIFF
--- a/utils/report.py
+++ b/utils/report.py
@@ -22,7 +22,7 @@ def get_json_from_report_output_file(**kwargs):
     report_path = os.getenv(constants.REPORT_OUTPUT_PATH)
     report_path = kwargs.get('report_path', report_path)
 
-    with open(report_path + "/static-report/output.js") as file:
+    with open(report_path + "/static-report/output.js", encoding='utf-8') as file:
         js_report = file.read()
     return json.loads(js_report.split('window["apps"] = ')[1])[0]
 


### PR DESCRIPTION
Now it passes on Windows
![image](https://github.com/konveyor-ecosystem/kantra-cli-tests/assets/59690591/b5bc7738-e46d-44f4-938e-b092f38a0bf2)
Linux passed as well
![image](https://github.com/konveyor-ecosystem/kantra-cli-tests/assets/59690591/a3633964-e92b-49c4-a301-c97a7750c65e)
