### PR TITLE
[RFR] Added test that no container is left after analysis was interrupted

### DIFF
--- a/tests/test_advanced_options.py
+++ b/tests/test_advanced_options.py
@@ -116,10 +116,9 @@ def test_no_container_leftovers(analysis_data):
 
     process.wait()
 
-    leftover = subprocess.run("podman ps | grep -v CONTAINER", shell=True, stdout=subprocess.PIPE, encoding='utf-8')
+    leftover = subprocess.run("podman ps", shell=True, stdout=subprocess.PIPE, encoding='utf-8')
     leftover_output = leftover.stdout.strip()
 
-    # assert len(leftover_output) == 0, "Output has non-zero length"
     for line in leftover_output.splitlines():
         assert not line.startswith("analysis-"), f"Found a leftover container with name: {line}"
         assert not line.startswith("provider-"), f"Found a leftover container with name: {line}"

--- a/tests/test_advanced_options.py
+++ b/tests/test_advanced_options.py
@@ -120,5 +120,5 @@ def test_no_container_leftovers(analysis_data):
     leftover_output = leftover.stdout.strip()
 
     for line in leftover_output.splitlines():
-        assert not line.startswith("analysis-"), f"Found a leftover container with name: {line}"
-        assert not line.startswith("provider-"), f"Found a leftover container with name: {line}"
+        assert "analysis-" not in line, f"Found a leftover analysis container: \n{line}"
+        assert "provider-" not in line, f"Found a leftover provider container: \n {line}"


### PR DESCRIPTION
$ pytest -s -v -k test_no_container_leftovers
================================================================== test session starts 
platform linux -- Python 3.9.20, pytest-7.2.1, pluggy-1.0.0 -- /usr/bin/python3.9
cachedir: .pytest_cache
rootdir: /home/igor/github.com/kantra-cli-tests
plugins: check-2.1.2
collected 29 items / 28 deselected / 1 selected                                                                                                                                                                  

tests/test_advanced_options.py::test_no_container_leftovers /home/igor/bin/mta-cli analyze --overwrite --input /home/igor/github.com/kantra-cli-tests/data/applications/jee-example-app-1.0.0.ear --output /home/igor/MTA/reports-automation --source weblogic --target eap7
PASSED