### PR TITLE
Add retry on github action failure

### DIFF
--- a/.github/actions/tests-linux-containerless-arm64/action.yaml
+++ b/.github/actions/tests-linux-containerless-arm64/action.yaml
@@ -43,6 +43,9 @@ runs:
       pip install -r requirements.txt
 
   - name: Run TIER0 analysis test
+    uses: nick-fields/retry@v3
+    timeout_minutes: 20
+    max_attempts: 3
     shell: bash
     run: |
       export KANTRA_CLI_PATH=/home/runner/.kantra/kantra

--- a/.github/actions/tests-linux-containerless-arm64/action.yaml
+++ b/.github/actions/tests-linux-containerless-arm64/action.yaml
@@ -44,16 +44,17 @@ runs:
 
   - name: Run TIER0 analysis test
     uses: nick-fields/retry@v3
-    timeout_minutes: 20
-    max_attempts: 3
-    shell: bash
-    run: |
-      export KANTRA_CLI_PATH=/home/runner/.kantra/kantra
-      export REPORT_OUTPUT_PATH=${{ github.workspace }}/report
-      export PROJECT_PATH=${{ github.workspace }}
-      export GIT_PASSWORD=${{ inputs.maven_token }}
+    with:
+      timeout_minutes: 20
+      max_attempts: 3
+      shell: bash
+      command: |
+        export KANTRA_CLI_PATH=/home/runner/.kantra/kantra
+        export REPORT_OUTPUT_PATH=${{ github.workspace }}/report
+        export PROJECT_PATH=${{ github.workspace }}
+        export GIT_PASSWORD=${{ inputs.maven_token }}
 
-      pytest -s tests/analysis/java/test_tier0.py
+        pytest -s tests/analysis/java/test_tier0.py
 
   - name: Save analysis output
     uses: actions/upload-artifact@v4

--- a/.github/actions/tests-linux-containerless/action.yaml
+++ b/.github/actions/tests-linux-containerless/action.yaml
@@ -43,6 +43,9 @@ runs:
       pip install -r requirements.txt
 
   - name: Run TIER0 analysis test
+    uses: nick-fields/retry@v3
+    timeout_minutes: 20
+    max_attempts: 3
     shell: bash
     run: |
       export KANTRA_CLI_PATH=/home/runner/.kantra/kantra

--- a/.github/actions/tests-linux-containerless/action.yaml
+++ b/.github/actions/tests-linux-containerless/action.yaml
@@ -44,16 +44,17 @@ runs:
 
   - name: Run TIER0 analysis test
     uses: nick-fields/retry@v3
-    timeout_minutes: 20
-    max_attempts: 3
-    shell: bash
-    run: |
-      export KANTRA_CLI_PATH=/home/runner/.kantra/kantra
-      export REPORT_OUTPUT_PATH=${{ github.workspace }}/report
-      export PROJECT_PATH=${{ github.workspace }}
-      export GIT_PASSWORD=${{ inputs.maven_token }}
+    with:
+      timeout_minutes: 20
+      max_attempts: 3
+      shell: bash
+      command: |
+        export KANTRA_CLI_PATH=/home/runner/.kantra/kantra
+        export REPORT_OUTPUT_PATH=${{ github.workspace }}/report
+        export PROJECT_PATH=${{ github.workspace }}
+        export GIT_PASSWORD=${{ inputs.maven_token }}
 
-      pytest -s tests/analysis/java/test_tier0.py
+        pytest -s tests/analysis/java/test_tier0.py
 
   - name: Save analysis output
     uses: actions/upload-artifact@v4

--- a/.github/actions/tests-linux-containers/action.yaml
+++ b/.github/actions/tests-linux-containers/action.yaml
@@ -48,16 +48,17 @@ runs:
 
   - name: Run TIER0 analysis test
     uses: nick-fields/retry@v3
-    timeout_minutes: 20
-    max_attempts: 3
-    shell: bash
-    run: |
-      export KANTRA_CLI_PATH=/home/runner/.kantra/kantra
-      export REPORT_OUTPUT_PATH=${{ github.workspace }}/report
-      export PROJECT_PATH=${{ github.workspace }}
-      export GIT_PASSWORD=${{ inputs.maven_token }}
+    with:
+      timeout_minutes: 20
+      max_attempts: 3
+      shell: bash
+      command: |
+        export KANTRA_CLI_PATH=/home/runner/.kantra/kantra
+        export REPORT_OUTPUT_PATH=${{ github.workspace }}/report
+        export PROJECT_PATH=${{ github.workspace }}
+        export GIT_PASSWORD=${{ inputs.maven_token }}
 
-      pytest -s tests/analysis/java/test_tier0.py
+        pytest -s tests/analysis/java/test_tier0.py
 
   - name: Save analysis output
     uses: actions/upload-artifact@v4

--- a/.github/actions/tests-linux-containers/action.yaml
+++ b/.github/actions/tests-linux-containers/action.yaml
@@ -47,6 +47,9 @@ runs:
       pip install -r requirements.txt
 
   - name: Run TIER0 analysis test
+    uses: nick-fields/retry@v3
+    timeout_minutes: 20
+    max_attempts: 3
     shell: bash
     run: |
       export KANTRA_CLI_PATH=/home/runner/.kantra/kantra

--- a/.github/actions/tests-mac-containerless-arm64/action.yaml
+++ b/.github/actions/tests-mac-containerless-arm64/action.yaml
@@ -50,6 +50,9 @@ runs:
       pip install -r requirements.txt
 
   - name: Run TIER0 analysis test
+    uses: nick-fields/retry@v3
+    timeout_minutes: 20
+    max_attempts: 3
     shell: bash
     run: |
       export PATH=$(brew --prefix)/opt/findutils/libexec/gnubin:$PATH

--- a/.github/actions/tests-mac-containerless-arm64/action.yaml
+++ b/.github/actions/tests-mac-containerless-arm64/action.yaml
@@ -51,17 +51,18 @@ runs:
 
   - name: Run TIER0 analysis test
     uses: nick-fields/retry@v3
-    timeout_minutes: 20
-    max_attempts: 3
-    shell: bash
-    run: |
-      export PATH=$(brew --prefix)/opt/findutils/libexec/gnubin:$PATH
-      export KANTRA_CLI_PATH=/Users/runner/.kantra/darwin-kantra
-      export REPORT_OUTPUT_PATH=${{ github.workspace }}/report
-      export PROJECT_PATH=${{ github.workspace }}
-      export GIT_PASSWORD=${{ inputs.maven_token }}
+    with:
+      timeout_minutes: 20
+      max_attempts: 3
+      shell: bash
+      command: |
+        export PATH=$(brew --prefix)/opt/findutils/libexec/gnubin:$PATH
+        export KANTRA_CLI_PATH=/Users/runner/.kantra/darwin-kantra
+        export REPORT_OUTPUT_PATH=${{ github.workspace }}/report
+        export PROJECT_PATH=${{ github.workspace }}
+        export GIT_PASSWORD=${{ inputs.maven_token }}
 
-      pytest -s tests/analysis/java/test_tier0.py
+        pytest -s tests/analysis/java/test_tier0.py
 
   - name: Save analysis output
     uses: actions/upload-artifact@v4

--- a/.github/actions/tests-mac-containers/action.yaml
+++ b/.github/actions/tests-mac-containers/action.yaml
@@ -52,16 +52,17 @@ runs:
 
   - name: Run TIER0 analysis test
     uses: nick-fields/retry@v3
-    timeout_minutes: 20
-    max_attempts: 3
-    shell: bash
-    run: |
-      export KANTRA_CLI_PATH=/Users/runner/.kantra/darwin-kantra
-      export REPORT_OUTPUT_PATH=${{ github.workspace }}/report
-      export PROJECT_PATH=${{ github.workspace }}
-      export GIT_PASSWORD=${{ inputs.maven_token }}
+    with:
+      timeout_minutes: 20
+      max_attempts: 3
+      shell: bash
+      command: |
+        export KANTRA_CLI_PATH=/Users/runner/.kantra/darwin-kantra
+        export REPORT_OUTPUT_PATH=${{ github.workspace }}/report
+        export PROJECT_PATH=${{ github.workspace }}
+        export GIT_PASSWORD=${{ inputs.maven_token }}
 
-      pytest -s tests/analysis/java/test_tier0.py
+        pytest -s tests/analysis/java/test_tier0.py
 
   - name: Save analysis output
     uses: actions/upload-artifact@v4

--- a/.github/actions/tests-mac-containers/action.yaml
+++ b/.github/actions/tests-mac-containers/action.yaml
@@ -51,6 +51,9 @@ runs:
       pip install -r requirements.txt
 
   - name: Run TIER0 analysis test
+    uses: nick-fields/retry@v3
+    timeout_minutes: 20
+    max_attempts: 3
     shell: bash
     run: |
       export KANTRA_CLI_PATH=/Users/runner/.kantra/darwin-kantra

--- a/.github/actions/tests-mac-containers/action.yaml
+++ b/.github/actions/tests-mac-containers/action.yaml
@@ -53,7 +53,7 @@ runs:
   - name: Run TIER0 analysis test
     uses: nick-fields/retry@v3
     with:
-      timeout_minutes: 20
+      timeout_minutes: 40
       max_attempts: 3
       shell: bash
       command: |

--- a/.github/actions/tests-windows-containerless/action.yaml
+++ b/.github/actions/tests-windows-containerless/action.yaml
@@ -41,6 +41,9 @@ runs:
       mkdir ${{ github.workspace }}\report
 
   - name: Run TIER0 analysis test
+    uses: nick-fields/retry@v3
+    timeout_minutes: 20
+    max_attempts: 3
     shell: cmd
     run: |
       set KANTRA_CLI_PATH=C:\Users\runneradmin\.kantra\windows-kantra.exe

--- a/.github/actions/tests-windows-containerless/action.yaml
+++ b/.github/actions/tests-windows-containerless/action.yaml
@@ -42,16 +42,17 @@ runs:
 
   - name: Run TIER0 analysis test
     uses: nick-fields/retry@v3
-    timeout_minutes: 20
-    max_attempts: 3
-    shell: cmd
-    run: |
-      set KANTRA_CLI_PATH=C:\Users\runneradmin\.kantra\windows-kantra.exe
-      set REPORT_OUTPUT_PATH=${{ github.workspace }}\report
-      set PROJECT_PATH=${{ github.workspace }}
-      set GIT_PASSWORD=${{ inputs.maven_token }}
+    with:
+      timeout_minutes: 20
+      max_attempts: 3
+      shell: cmd
+      command: |
+        set KANTRA_CLI_PATH=C:\Users\runneradmin\.kantra\windows-kantra.exe
+        set REPORT_OUTPUT_PATH=${{ github.workspace }}\report
+        set PROJECT_PATH=${{ github.workspace }}
+        set GIT_PASSWORD=${{ inputs.maven_token }}
 
-      pytest -s tests/analysis/java/test_tier0.py
+        pytest -s tests/analysis/java/test_tier0.py
 
   - name: Save analysis output
     uses: actions/upload-artifact@v4


### PR DESCRIPTION
In order to bypass external services (like maven repos) failures, adding automatic retry to CLI tests execution github workflows.

Real errors will appear little slower, but that's hopefully acceptable, could be updated in future.