### PR TITLE
[RFR] Added test to run custom rules analysis with disabled builtin rules

### DIFF
--- a/tests/analysis/dotnet/test_dotnet_analysis.py
+++ b/tests/analysis/dotnet/test_dotnet_analysis.py
@@ -3,7 +3,7 @@ import subprocess
 
 from utils import constants
 from utils.command import build_analysis_command
-from utils.common import extract_zip_to_temp_dir, verify_triggered_rule
+from utils.common import extract_zip_to_temp_dir, verify_triggered_rules
 from utils.report import assert_story_points_from_report_file, get_json_from_report_output_file
 
 
@@ -38,4 +38,4 @@ def test_hello_world_linux_analysis_with_rules(dotnet_analysis_data):
         assert 'Static report created' in output
         assert_story_points_from_report_file()
         report_data = get_json_from_report_output_file()
-        verify_triggered_rule(report_data, ['custom-rule-dotnet-framework'])
+        verify_triggered_rules(report_data, ['custom-rule-dotnet-framework'])

--- a/tests/analysis/dotnet/test_dotnet_analysis.py
+++ b/tests/analysis/dotnet/test_dotnet_analysis.py
@@ -38,4 +38,4 @@ def test_hello_world_linux_analysis_with_rules(dotnet_analysis_data):
         assert 'Static report created' in output
         assert_story_points_from_report_file()
         report_data = get_json_from_report_output_file()
-        verify_triggered_rule(report_data, 'custom-rule-dotnet-framework')
+        verify_triggered_rule(report_data, ['custom-rule-dotnet-framework'])

--- a/tests/analysis/java/test_java_analysis.py
+++ b/tests/analysis/java/test_java_analysis.py
@@ -84,4 +84,4 @@ def test_dependency_rule_analysis(analysis_data):
 
     report_data = get_json_from_report_output_file()
 
-    verify_triggered_rule(report_data, 'tackle-dependency-test-rule')
+    verify_triggered_rule(report_data, ['tackle-dependency-test-rule'])

--- a/tests/analysis/java/test_java_analysis.py
+++ b/tests/analysis/java/test_java_analysis.py
@@ -8,7 +8,7 @@ import pytest
 
 from utils import constants
 from utils.command import build_analysis_command
-from utils.common import run_containerless_parametrize, verify_triggered_rule
+from utils.common import run_containerless_parametrize, verify_triggered_rules
 from utils.manage_maven_credentials import manage_credentials_in_maven_xml
 from utils.report import assert_story_points_from_report_file, get_json_from_report_output_file
 
@@ -84,4 +84,4 @@ def test_dependency_rule_analysis(analysis_data):
 
     report_data = get_json_from_report_output_file()
 
-    verify_triggered_rule(report_data, ['tackle-dependency-test-rule'])
+    verify_triggered_rules(report_data, ['tackle-dependency-test-rule'])

--- a/tests/analysis/python/test_python_analysis.py
+++ b/tests/analysis/python/test_python_analysis.py
@@ -4,17 +4,12 @@ import subprocess
 from utils import constants
 from utils.command import build_analysis_command
 from utils.common import verify_triggered_rule
-from utils.report import assert_story_points_from_report_file, get_json_from_report_output_file
+from utils.report import get_json_from_report_output_file
 
 
 def test_python_analysis_with_rules(python_analysis_data):
     application_data = python_analysis_data["python_app_project"]
-    application_path = os.path.join(
-        os.getenv(constants.PROJECT_PATH),
-        'data',
-        'applications',
-        application_data['file_name']
-    )
+
     custom_rules_path = os.path.join(os.getenv(constants.PROJECT_PATH), 'data','yaml', 'python_rules.yaml')
 
     command = build_analysis_command(
@@ -34,6 +29,5 @@ def test_python_analysis_with_rules(python_analysis_data):
 
     assert 'generating static report' in output
 
-    for rule_id in ['python-sample-rule-001', 'python-sample-rule-002']:
-        verify_triggered_rule(report_data, rule_id, 1)
+    verify_triggered_rule(report_data, ['python-sample-rule-001', 'python-sample-rule-002'], 1)
 

--- a/tests/analysis/python/test_python_analysis.py
+++ b/tests/analysis/python/test_python_analysis.py
@@ -3,7 +3,7 @@ import subprocess
 
 from utils import constants
 from utils.command import build_analysis_command
-from utils.common import verify_triggered_rule
+from utils.common import verify_triggered_rules
 from utils.report import get_json_from_report_output_file
 
 
@@ -29,5 +29,5 @@ def test_python_analysis_with_rules(python_analysis_data):
 
     assert 'generating static report' in output
 
-    verify_triggered_rule(report_data, ['python-sample-rule-001', 'python-sample-rule-002'], 1)
+    verify_triggered_rules(report_data, ['python-sample-rule-001', 'python-sample-rule-002'], 1)
 

--- a/tests/test_advanced_options.py
+++ b/tests/test_advanced_options.py
@@ -5,7 +5,7 @@ import time
 
 from utils import constants
 from utils.command import build_analysis_command, build_discovery_command
-from utils.common import run_containerless_parametrize, verify_triggered_rule
+from utils.common import run_containerless_parametrize, verify_triggered_rules
 from utils.manage_maven_credentials import manage_credentials_in_maven_xml
 from utils.report import assert_story_points_from_report_file, get_json_from_report_output_file, clearReportDir
 
@@ -49,7 +49,7 @@ def test_custom_rules(analysis_data):
     assert_story_points_from_report_file()
 
     report_data = get_json_from_report_output_file()
-    verify_triggered_rule(report_data, ['Test-002-00001'])
+    verify_triggered_rules(report_data, ['Test-002-00001'])
 
 # Automates Bug 4784
 def test_description_display_in_report(analysis_data):
@@ -168,7 +168,8 @@ def test_language_discovery(analysis_data, python_analysis_data, golang_analysis
             assert language in output, f"Language {language} was not detected in the {application_data['app_name']} app"
 
 
-def test_custom_rules_disable_default(analysis_data):
+def test_custom_rules_disable_default_issue_769(analysis_data):
+    # This test hits a known issue https://github.com/konveyor/analyzer-lsp/issues/769
     application_data = analysis_data['tackle-testapp-project']
     assert os.getenv(constants.PROJECT_PATH) is not None
     custom_rule_path = os.path.join(os.getenv(constants.PROJECT_PATH), 'data', 'yaml', 'test-rules')
@@ -212,4 +213,4 @@ def test_custom_rules_disable_default(analysis_data):
     ]
 
     report_data = get_json_from_report_output_file()
-    verify_triggered_rule(report_data, expected_rule_id_list)
+    verify_triggered_rules(report_data, expected_rule_id_list)

--- a/tests/test_advanced_options.py
+++ b/tests/test_advanced_options.py
@@ -49,7 +49,7 @@ def test_custom_rules(analysis_data):
     assert_story_points_from_report_file()
 
     report_data = get_json_from_report_output_file()
-    verify_triggered_rule(report_data, 'Test-002-00001')
+    verify_triggered_rule(report_data, ['Test-002-00001'])
 
 # Automates Bug 4784
 def test_description_display_in_report(analysis_data):
@@ -166,3 +166,50 @@ def test_language_discovery(analysis_data, python_analysis_data, golang_analysis
         output = subprocess.run(command, shell=True, check=True, stdout=subprocess.PIPE, encoding='utf-8').stdout
         for language in application_data["languages"]:
             assert language in output, f"Language {language} was not detected in the {application_data['app_name']} app"
+
+
+def test_custom_rules_disable_default(analysis_data):
+    application_data = analysis_data['tackle-testapp-project']
+    assert os.getenv(constants.PROJECT_PATH) is not None
+    custom_rule_path = os.path.join(os.getenv(constants.PROJECT_PATH), 'data', 'yaml', 'test-rules')
+
+    command = build_analysis_command(
+        application_data['file_name'],
+        application_data['source'],
+        application_data['target'],
+        **{
+            'rules': custom_rule_path,
+            'enable-default-rulesets': 'false'
+        }
+    )
+
+    output = subprocess.run(command, shell=True, check=True, stdout=subprocess.PIPE, encoding='utf-8').stdout
+
+    assert 'generating static report' in output
+    assert_story_points_from_report_file()
+
+    expected_rule_id_list = [
+        'basic-location-001',
+        'basic-location-002',
+        'basic-location-003',
+        'basic-location-004',
+        'basic-location-005',
+        'basic-location-006',
+        'basic-location-007',
+        'basic-location-008',
+        'basic-location-009',
+        'basic-location-010',
+        'basic-location-011',
+        'basic-location-012',
+        'basic-location-013',
+        'basic-location-014',
+        'basic-location-015',
+        'basic-location-016',
+        'basic-location-017',
+        'basic-location-018',
+        'basic-location-019',
+        'basic-location-020'
+    ]
+
+    report_data = get_json_from_report_output_file()
+    verify_triggered_rule(report_data, expected_rule_id_list)

--- a/utils/common.py
+++ b/utils/common.py
@@ -46,21 +46,22 @@ def run_containerless_parametrize(func):
 
     return wrapper
 
-def verify_triggered_rule(report_data, rule_id: str, expected_unmatched_rules = 0):
+def verify_triggered_rule(report_data, rule_id_list, expected_unmatched_rules = 0):
     """
 
     Args:
         report_data: Report data that includes rulesets
-        rule_id: actual rule ID we are looking for
+        rule_id_list: List of actual rule IDs we are looking for
         expected_unmatched_rules: Sometimes rulesets can include unmatched rules (on purpose) so expected_unmatched_rules was added to avoid failure
 
     Returns:
 
     """
-    ruleset = next((item for item in report_data['rulesets'] if rule_id in item.get('violations', {})), None)
+    for rule_id in rule_id_list:
+        ruleset = next((item for item in report_data['rulesets'] if rule_id in item.get('violations', {})), None)
 
-    assert ruleset is not None, "Ruleset property not found in output"
-    assert len(ruleset.get('skipped', [])) == 0, "Custom Rule was skipped"
-    assert len(ruleset.get('unmatched', [])) == expected_unmatched_rules, "Custom Rule was unmatched"
-    assert 'violations' in ruleset, "Custom rules didn't trigger any violation"
-    assert rule_id in ruleset['violations'], "The test rule triggered no violations"
+        assert ruleset is not None, f"Ruleset property {rule_id} not found in output"
+        assert len(ruleset.get('skipped', [])) == 0, f"Custom Rule {rule_id} was skipped"
+        assert len(ruleset.get('unmatched', [])) == expected_unmatched_rules, f'Custom Rule {rule_id} was unmatched'
+        assert 'violations' in ruleset, f"Custom rule {rule_id} didn't trigger any violation"
+        assert rule_id in ruleset['violations'], f"The test rule {rule_id} triggered no violations"

--- a/utils/common.py
+++ b/utils/common.py
@@ -46,7 +46,7 @@ def run_containerless_parametrize(func):
 
     return wrapper
 
-def verify_triggered_rule(report_data, rule_id_list, expected_unmatched_rules = 0):
+def verify_triggered_rules(report_data, rule_id_list, expected_unmatched_rules = 0):
     """
 
     Args:


### PR DESCRIPTION
Added test to run custom rules analysis with disabled builtin rules
Refactored verify_triggered_rules() to accept array of rules instead of a single one 
Did respective changes in other tests that use this function