### PR TITLE
Update macOS version for test suite

### DIFF
--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -134,7 +134,7 @@ jobs:
   #      maven_token: ${{ secrets.GH_TOKEN }}
 
   tests-mac-containers:
-    runs-on: macos-13 # Intel, M1-based macos-latest doesn't support nested virtualization (containers)
+    runs-on: macos-15-intel # Intel, M1-based macos-latest doesn't support nested virtualization (containers)
     needs: make-kantra-bundle
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
MacOS 13 is going to be deprecated, updating to 15 (while keeping intel to have nested virt available).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test infrastructure to use a newer macOS runner environment.

---

**Note:** This release contains no user-facing changes. The update is limited to internal testing infrastructure improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->