### PR TITLE
Update actions names to konveyor org

### DIFF
--- a/.github/workflows/nightly-main-latest.yaml
+++ b/.github/workflows/nightly-main-latest.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test-suite:
-    uses: konveyor-ecosystem/kantra-cli-tests/.github/workflows/test-suite.yaml@main
+    uses: konveyor/kantra-cli-tests/.github/workflows/test-suite.yaml@main
     secrets: inherit
     with:
       tag: latest

--- a/.github/workflows/nightly-main-release07.yaml
+++ b/.github/workflows/nightly-main-release07.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test-suite:
-    uses: konveyor-ecosystem/kantra-cli-tests/.github/workflows/test-suite.yaml@main # TODO: a corresponding kantra-cli-tests branch will be needed with next releases
+    uses: konveyor/kantra-cli-tests/.github/workflows/test-suite.yaml@release-0.7
     secrets: inherit
     with:
       tag: release-0.7

--- a/.github/workflows/nightly-main-release08.yaml
+++ b/.github/workflows/nightly-main-release08.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test-suite:
-    uses: konveyor-ecosystem/kantra-cli-tests/.github/workflows/test-suite.yaml@main # TODO: a corresponding kantra-cli-tests branch will be needed with next releases
+    uses: konveyor/kantra-cli-tests/.github/workflows/test-suite.yaml@release-0.8
     secrets: inherit
     with:
       tag: release-0.8

--- a/.github/workflows/pr-gating-main.yaml
+++ b/.github/workflows/pr-gating-main.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   test-suite:
-    uses: konveyor-ecosystem/kantra-cli-tests/.github/workflows/test-suite.yaml@main
+    uses: konveyor/kantra-cli-tests/.github/workflows/test-suite.yaml@main
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
     with:


### PR DESCRIPTION
It looks PR gating workfows were not started on
https://github.com/konveyor/kantra-cli-tests/pull/105, creating this PR renaming actions called from gating (and nightly) workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configurations to reference test suite sources from an updated repository location, ensuring workflows continue to run with the latest test infrastructure across multiple release branches and main branch pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->