### PR TITLE
Fix Python version on MacOS

### DIFF
--- a/.github/actions/tests-mac-containers/action.yaml
+++ b/.github/actions/tests-mac-containers/action.yaml
@@ -21,7 +21,7 @@ runs:
   - name: Setup Python
     uses: actions/setup-python@v5
     with:
-      python-version: '3.11'
+      python-version: '3.12'
   - name: Setup Homebrew
     uses: Homebrew/actions/setup-homebrew@master
   - name: Install podman


### PR DESCRIPTION
Setting up python 3.12 manually ater update on MacOS test action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI updated to ensure a consistent Python 3.12 runtime is set up during test workflows.
  * Change is additive to the test workflow sequence and does not alter error handling or test logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->