### PR TITLE
[RFR] Added tests to support proxy validation

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -13,9 +13,17 @@ pytest_plugins = [
 def load_env():
     load_dotenv()
 
-def pytest_runtest_setup(item):
-    item.start_time = time.perf_counter()
+_run_started_at: dict[str, float] = {}
+
+
+def pytest_runtest_logstart(nodeid, location):
+    # Unconditionally skipped tests never run pytest_runtest_setup but still
+    # run pytest_runtest_teardown; logstart always runs for each collected item.
+    _run_started_at[nodeid] = time.perf_counter()
+
 
 def pytest_runtest_teardown(item):
-    duration = time.perf_counter() - item.start_time
-    print(f"\nTest {item.name} took {duration:.4f} seconds")
+    started = _run_started_at.pop(item.nodeid, None)
+    if started is not None:
+        duration = time.perf_counter() - started
+        print(f"\nTest {item.name} took {duration:.4f} seconds")

--- a/squid/squid.conf
+++ b/squid/squid.conf
@@ -1,0 +1,18 @@
+# Defining port
+http_port 3128
+
+# Allowing all traffic
+acl allsrc src all
+http_access allow allsrc
+
+# Forwarding logs to console
+access_log stdio:/dev/stdout
+cache_log /tmp/cache.log
+pid_filename /tmp/squid.pid
+
+# Verbose logging
+access_log /var/log/squid/access.log squid
+cache_log /var/log/squid/cache.log
+debug_options ALL,1
+
+cache_dir ufs /var/spool/squid 100 16 256

--- a/tests/analysis/java/test_analysis.py
+++ b/tests/analysis/java/test_analysis.py
@@ -3,8 +3,8 @@ import os
 import pytest
 from deepdiff import DeepDiff
 
+import utils.common
 from fixtures.analysis import ci_data
-from utils import constants
 from utils.command import build_analysis_command, run_command_stream_output
 from utils.output import normalize_output
 from utils.report import assert_story_points_from_report_file, get_dict_from_output_yaml_file
@@ -14,7 +14,7 @@ from utils.report import assert_story_points_from_report_file, get_dict_from_out
                          ids=lambda case: f"{case['name']}")
 def test_bvp_issue_analyzer_901(application_data):
     reference_data_path = os.path.join(
-        os.getenv(constants.PROJECT_PATH),
+        utils.common.get_project_path(),
         "data", "ci", "shared_tests", application_data['referencesDir']
     )
 
@@ -33,7 +33,7 @@ def test_bvp_issue_analyzer_901(application_data):
     # Parsing report and reference
     report_data = normalize_output(
         get_dict_from_output_yaml_file(),
-        os.path.join(os.getenv(constants.PROJECT_PATH), 'data', 'applications', application_data['filename'])
+        os.path.join(utils.common.get_project_path(), 'data', 'applications', application_data['filename'])
     )
     reference_data = get_dict_from_output_yaml_file(
         filename="output.yaml",
@@ -42,7 +42,7 @@ def test_bvp_issue_analyzer_901(application_data):
 
     reference_data = normalize_output(
         reference_data,
-        os.path.join(os.getenv(constants.PROJECT_PATH), 'data', 'applications', application_data['filename'])
+        os.path.join(utils.common.get_project_path(), 'data', 'applications', application_data['filename'])
     )
 
     diff = DeepDiff(report_data, reference_data, ignore_order=True)

--- a/tests/analysis/java/test_java_analysis.py
+++ b/tests/analysis/java/test_java_analysis.py
@@ -6,6 +6,7 @@ import subprocess
 
 import pytest
 
+import utils.common
 from utils import constants
 from utils.command import build_analysis_command, run_command_stream_output
 from utils.common import get_project_path, run_containerless_parametrize, verify_triggered_rules
@@ -27,7 +28,7 @@ def test_standard_analysis(app_name, analysis_data, additional_args):
             maven_token = get_default_token()
         raw_settings = raw_settings.replace('GITHUB_USER', os.getenv(constants.GIT_USERNAME, 'konveyor-read-only-bot'))
         raw_settings = raw_settings.replace('GITHUB_TOKEN', maven_token)
-        input_path = os.path.join(os.getenv(constants.PROJECT_PATH), 'data', 'applications', application_data['file_name'])
+        input_path = os.path.join(utils.common.get_project_path(), 'data', 'applications', application_data['file_name'])
         settings_path = input_path + "_settings.xml"  
         with open(settings_path, 'w') as f:
             f.write(raw_settings)

--- a/tests/test_advanced_options.py
+++ b/tests/test_advanced_options.py
@@ -6,16 +6,16 @@ import time
 
 from utils import constants
 from utils.command import build_analysis_command, build_discovery_command, run_command_stream_output
-from utils.common import run_containerless_parametrize, verify_triggered_rules, verify_triggered_yaml_rules
+import utils.common
 from utils.manage_maven_credentials import manage_credentials_in_maven_xml
 from utils.report import assert_story_points_from_report_file, get_json_from_report_output_js_file, clearReportDir, \
     get_dict_from_output_yaml_file
+from utils.squid import get_squid_logs, start_squid_container, stop_squid_container
 
 
 # Polarion TC 373
 def test_skip_report(analysis_data):
     application_data = analysis_data['administracion_efectivo']
-    report_path = os.getenv(constants.REPORT_OUTPUT_PATH)
 
     command = build_analysis_command(
         application_data['file_name'],
@@ -28,15 +28,15 @@ def test_skip_report(analysis_data):
 
     assert 'Analysis complete!' in output
 
-    assert os.path.exists(report_path + '/static-report/index.html') is False
-    assert os.path.exists(report_path + '/output.yaml') is True
-    assert os.path.exists(report_path + '/analysis.log') is True
+    assert os.path.exists(os.path.join(utils.common.get_report_path(), 'static-report', 'index.html')) is False
+    assert os.path.exists(os.path.join(utils.common.get_report_path(), 'output.yaml'))is True
+    assert os.path.exists(os.path.join(utils.common.get_report_path(), 'analysis.log')) is True
 
 
 # Polarion TC 374
 def test_custom_rules(analysis_data):
     application_data = analysis_data['administracion_efectivo']
-    custom_rule_path = os.path.join(os.getenv(constants.PROJECT_PATH), 'data', 'yaml', '01-test-jee.windup.yaml')
+    custom_rule_path = os.path.join(utils.common.get_project_path(), 'data', 'yaml', '01-test-jee.windup.yaml')
 
     command = build_analysis_command(
         application_data['file_name'],
@@ -51,7 +51,7 @@ def test_custom_rules(analysis_data):
     assert_story_points_from_report_file()
 
     report_data = get_json_from_report_output_js_file()
-    verify_triggered_rules(report_data, ['Test-002-00001'])
+    utils.common.verify_triggered_rules(report_data, ['Test-002-00001'])
 
 # Automates Bug 4784
 def test_description_display_in_report(analysis_data):
@@ -77,7 +77,7 @@ def test_description_display_in_report(analysis_data):
     assert "Removed SessionBean interface" in ruleset["violations"]["singleton-sessionbean-00001"]["description"], "The reported issue did not include the description"
 
 
-@run_containerless_parametrize
+@utils.common.run_containerless_parametrize
 def test_bulk_analysis(analysis_data, additional_args):
     applications = [analysis_data['administracion_efectivo'], analysis_data['tackle-testapp-project']]
     clearReportDir()
@@ -104,11 +104,11 @@ def test_bulk_analysis(analysis_data, additional_args):
 
 
 # Validation for Jira ticket MTA-3779
-@run_containerless_parametrize
+@utils.common.run_containerless_parametrize
 def test_analysis_of_private_repo(analysis_data, additional_args):
     application_data = analysis_data['tackle-testapp-public']
     custom_maven_settings = os.path.join(
-        os.getenv(constants.PROJECT_PATH),
+        utils.common.get_project_path(),
         'data',
         'xml',
         'tackle-testapp-public-settings.xml'
@@ -200,7 +200,7 @@ def test_custom_rules_disable_default_issue_781_855(analysis_data):
     # This test hits 2 known issues https://github.com/konveyor/analyzer-lsp/issues/781 & https://github.com/konveyor/analyzer-lsp/issues/855
     application_data = analysis_data['tackle-testapp-project']
     assert os.getenv(constants.PROJECT_PATH) is not None
-    custom_rule_path = os.path.join(os.getenv(constants.PROJECT_PATH), 'data', 'yaml', 'test-rules')
+    custom_rule_path = os.path.join(utils.common.get_project_path(), 'data', 'yaml', 'test-rules', 'java')
 
     command = build_analysis_command(
         application_data['file_name'],
@@ -241,4 +241,96 @@ def test_custom_rules_disable_default_issue_781_855(analysis_data):
     ]
 
     report_data = get_dict_from_output_yaml_file()
-    verify_triggered_yaml_rules(report_data, expected_rule_id_list)
+    utils.common.verify_triggered_yaml_rules(report_data, expected_rule_id_list)
+
+
+@utils.common.run_containerless_parametrize
+def test_https_proxy(analysis_data, additional_args):
+    """Test analysis using --https-proxy option to connect to outside world"""
+    utils.common.clear_maven_cache()
+    application_data = analysis_data['tackle-testapp-public']
+    proxy_url = os.getenv('HTTPS_PROXY_URL', 'http://localhost:3128')
+    squid_container = os.getenv('SQUID_CONTAINER_NAME', 'squid-proxy')
+    custom_maven_settings = os.path.join(
+        utils.common.get_project_path(),
+        'data',
+        'xml',
+        'tackle-testapp-public-settings.xml'
+    )
+    manage_credentials_in_maven_xml(custom_maven_settings)
+
+    start_squid_container(squid_container)
+
+    command = build_analysis_command(
+        application_data['file_name'],
+        application_data['sources'],
+        application_data['targets'],
+        **{
+            'https-proxy': proxy_url,
+            'maven-settings': custom_maven_settings
+        },
+        **additional_args
+    )
+
+    output = run_command_stream_output(command)
+    assert 'Analysis complete!' in output
+
+    # Verify proxy was used by checking squid logs
+    squid_logs = get_squid_logs(squid_container)
+    assert len(squid_logs) > 0, "Squid proxy logs are empty - proxy may not have been used"
+    assert 'CONNECT' in squid_logs, "No HTTPS CONNECT requests found in squid logs"
+
+    report_data = get_json_from_report_output_js_file(False)
+    assert len(report_data[0]['depItems']) > 0, "No dependencies were found"
+    violations = [item for item in report_data[0]['rulesets'] if item.get('violations')]
+    assert len(violations) > 0, "Expected issues are missing"
+
+    stop_squid_container(squid_container)
+    manage_credentials_in_maven_xml(custom_maven_settings, True)
+
+
+
+@utils.common.run_containerless_parametrize
+def test_http_proxy(analysis_data, additional_args):
+    """Test analysis using --http-proxy option to connect to outside world"""
+    utils.common.clear_maven_cache()
+    application_data = analysis_data['tackle-testapp-public']
+    proxy_url = os.getenv('HTTP_PROXY_URL', 'http://localhost:3128')
+    squid_container = os.getenv('SQUID_CONTAINER_NAME', 'squid-proxy')
+
+    custom_maven_settings = os.path.join(
+        utils.common.get_project_path(),
+        'data',
+        'xml',
+        'tackle-testapp-public-settings.xml'
+    )
+    manage_credentials_in_maven_xml(custom_maven_settings)
+
+    start_squid_container(squid_container)
+
+    command = build_analysis_command(
+        application_data['file_name'],
+        application_data['sources'],
+        application_data['targets'],
+        **{
+            'https-proxy': proxy_url,
+            'maven-settings': custom_maven_settings
+        },
+        **additional_args
+    )
+
+    output = run_command_stream_output(command)
+    assert 'Analysis complete!' in output
+
+    # Verify proxy was used by checking squid logs
+    squid_logs = get_squid_logs(squid_container)
+    assert len(squid_logs) > 0, "Squid proxy logs are empty - proxy may not have been used"
+    assert 'TCP_' in squid_logs or 'CONNECT' in squid_logs, "No HTTP requests found in squid logs"
+
+    report_data = get_json_from_report_output_js_file(False)
+    assert len(report_data[0]['depItems']) > 0, "No dependencies were found"
+    violations = [item for item in report_data[0]['rulesets'] if item.get('violations')]
+    assert len(violations) > 0, "Expected issues are missing"
+
+    stop_squid_container(squid_container)
+    manage_credentials_in_maven_xml(custom_maven_settings, True)

--- a/utils/common.py
+++ b/utils/common.py
@@ -1,5 +1,6 @@
 import os
 import platform
+import shutil
 import subprocess
 import tempfile
 import zipfile
@@ -20,6 +21,7 @@ __all__ = [
     "extract_rules",
     "verify_triggered_yaml_rules",
     "extract_name_and_violations_from_dictionary",
+    "clear_maven_cache",
 ]
 
 
@@ -228,6 +230,17 @@ def get_report_path():
     if not value:
         raise RuntimeError("REPORT_OUTPUT_PATH is not set")
     return value
+
+
+def clear_maven_cache():
+    """
+    Remove the local Maven directory (``~/.m2`` on Linux and macOS,
+    ``%USERPROFILE%\\.m2`` on Windows). No-op if the directory does not exist.
+    """
+    m2_dir = os.path.join(os.path.expanduser("~"), ".m2")
+    if os.path.isdir(m2_dir):
+        shutil.rmtree(m2_dir)
+
 
 def get_profile_path(config_data):
     command = [get_cli_path(),

--- a/utils/squid.py
+++ b/utils/squid.py
@@ -1,0 +1,60 @@
+import subprocess
+import time
+from pathlib import Path
+from utils.common import get_project_path
+
+
+def get_squid_logs(container_name='squid-proxy'):
+    """Fetch logs from squid proxy container"""
+    result = subprocess.run(
+        ['podman', 'logs', container_name],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        encoding='utf-8'
+    )
+    return result.stdout
+
+
+def start_squid_container(container_name='squid-proxy'):
+    """Start squid proxy container"""
+    project_root = Path(get_project_path())
+    config_path = project_root / 'squid' / 'squid.conf'
+
+    if not config_path.exists():
+        raise FileNotFoundError(f"Config file not found at {config_path}")
+
+    stop_squid_container(container_name)
+
+    cmd = [
+        'podman', 'run', '-d',
+        '--name', container_name,
+        '-p', '3128:3128',
+        '-v', f'{config_path}:/etc/squid/squid.conf:Z',
+        'ubuntu/squid'
+    ]
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        print(f"Container started ID: {result.stdout.strip()}")
+
+    except subprocess.CalledProcessError as e:
+        print(f"Error starting container: {e.stderr}")
+        raise
+
+
+def stop_squid_container(container_name='squid-proxy'):
+    """Stop squid proxy container"""
+    subprocess.run(['podman', 'rm', '-f', container_name],
+                   stdout=subprocess.DEVNULL,
+                   stderr=subprocess.DEVNULL)
+
+
+def clear_squid_logs(container_name='squid-proxy'):
+    """Restart squid container to clear logs before test"""
+    subprocess.run(['podman', 'restart', container_name], check=True)
+    time.sleep(2)  # Wait for squid to start


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Squid proxy configuration for local testing (proxy on port 3128, logging to stdout and files).

* **Tests**
  * Added HTTP and HTTPS proxy integration tests that validate analysis through a proxy and inspect proxy traffic.
  * Updated test suites to use shared test helpers and improved timing reporting.

* **Chores**
  * Added a helper to clear local Maven cache used by tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/konveyor/kantra-cli-tests/pull/123)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->