### PR TITLE
[RFR] Added custom maven config file to tackle-test app

### DIFF
--- a/tests/test_advanced_options.py
+++ b/tests/test_advanced_options.py
@@ -109,7 +109,8 @@ def test_analysis_of_private_repo(analysis_data, additional_args):
     application_data = analysis_data['tackle-testapp-public']
     custom_maven_settings = os.path.join(
         os.getenv(constants.PROJECT_PATH),
-        'data/xml',
+        'data',
+        'xml',
         'tackle-testapp-public-settings.xml'
     )
     manage_credentials_in_maven_xml(custom_maven_settings)


### PR DESCRIPTION
This is required to fix test that were hanging on Windows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Reorganized test resource path construction for clarity and consistency
  * Added automatic management of Maven credentials during test runs, including setup and cleanup
  * Ensured tests pass an explicit Maven settings parameter into analysis commands
  * Fixed parameterization values in tests to correct test behavior

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->