### PR TITLE
Fix codeSnip whitespace, tags in output, and Linux container kantraDir

### DIFF
--- a/.github/actions/tests-linux-containers/action.yaml
+++ b/.github/actions/tests-linux-containers/action.yaml
@@ -34,6 +34,8 @@ runs:
   - name: Configure Test Environment
     shell: bash
     run: |
+      mkdir -p /home/runner/.config
+      ln -sf /home/runner/.kantra /home/runner/.config/.kantra
       chmod +x /home/runner/.kantra/kantra
       mkdir ${{ github.workspace }}/report
       # Temporary dirty workaround to execute container kantra (with run-local=false)

--- a/data/expected/java_analysis/tackle-testapp-public-cloud-readiness/output.yaml
+++ b/data/expected/java_analysis/tackle-testapp-public-cloud-readiness/output.yaml
@@ -7,7 +7,7 @@
       description: File system - Java IO
       effort: 1
       incidents:
-      - codeSnip: 14           InputStream inputStream = new FileInputStream("/opt/config/configuration.properties");
+      - codeSnip: 14 InputStream inputStream = new FileInputStream("/opt/config/configuration.properties");
         lineNumber: 14
         message: "An application running inside a container could lose access to a\
           \ file in local storage.\n\n Recommendations\n\n The following recommendations\
@@ -39,7 +39,6 @@
         url: https://12factor.net/logs
 - name: discovery-rules
   tags:
-  - EJB XML
   - Java Source
   - Maven XML
   - Properties
@@ -49,7 +48,7 @@
       description: Hardcoded IP Address
       effort: 1
       incidents:
-      - codeSnip: 2   jdbc.url=jdbc:oracle:thin:@10.19.2.93:1521:xe
+      - codeSnip: 2 jdbc.url=jdbc:oracle:thin:@10.19.2.93:1521:xe
         lineNumber: 2
         message: When migrating environments, hard-coded IP addresses may need to
           be modified or eliminated.
@@ -61,8 +60,6 @@
 - description: This ruleset provides analysis of logging libraries.
   name: technology-usage
   tags:
-  - Bean=EJB XML
-  - Connect=EJB XML
   - Connect=Servlet
   - Embedded Spring Data JPA
   - Embedded framework - Micrometer
@@ -82,7 +79,6 @@
   - HTTP=Servlet
   - Integration=Micrometer
   - Inversion of Control=Spring DI
-  - Java EE=EJB XML
   - Java EE=JPA named queries
   - Java EE=Servlet
   - Java Servlet

--- a/utils/output.py
+++ b/utils/output.py
@@ -19,10 +19,9 @@ def assert_analysis_output_violations(expected_output_dir, output_dir, input_roo
     got_output_normalized_path = got_output_path + ".normalized.yaml"
 
     # create a preprocessed/normalized outfile file to allow its comparison across platforms and setups
+    got_output = normalize_output(got_output, input_root_path)
     with open(got_output_normalized_path, 'w') as f:
-            yaml.dump(normalize_output(got_output, input_root_path), f)
-    with open(got_output_normalized_path, encoding='utf-8') as file:
-        got_output = yaml.safe_load(file)
+        yaml.dump(got_output, f)
 
     if not os.path.exists(expected_output_dir):
         os.mkdir(expected_output_dir)
@@ -36,7 +35,7 @@ def assert_analysis_output_violations(expected_output_dir, output_dir, input_roo
     else:
         with open(expected_output_path) as f:
             expected_output = yaml.safe_load(f)
-
+        expected_output = normalize_output(expected_output, input_root_path)
     assert got_output == expected_output, "Got different analysis output: \n%s" % get_files_diff(expected_output_path, got_output_normalized_path)
 
 
@@ -96,6 +95,7 @@ def get_dict_from_output_file(filename, dir=None, **kwargs):
 def get_files_diff(a, b):
     return os.popen("diff -u '%s' '%s'" % (a, b)).read()
 
+
 def normalize_output(rulesets: dict, input_root_path):
     """
         Does a pruning on output file to delete not used fields (skipped and unmatched rules),
@@ -119,7 +119,9 @@ def normalize_output(rulesets: dict, input_root_path):
                             for line in incident['codeSnip'].splitlines():
                                 line = line.strip()
                                 if line.startswith(str(incident['lineNumber'])):
-                                    incident['codeSnip'] = line
+                                    line_no_str = str(incident['lineNumber'])
+                                    after_number = line[len(line_no_str):].lstrip()
+                                    incident['codeSnip'] = line_no_str + ' ' + after_number
                                     break
                             # normalize incidents path to make compatible container with containerless, fix slashes, etc.
                             incident['uri'] = trim_incident_uri(repr(incident['uri']), repr(input_root_path))


### PR DESCRIPTION
Tags removed after fixing builtin.xml rule: https://github.com/konveyor/rulesets/pull/302/changes/4c984111d4f9a7e08a11b25ad6864e26625586a6 

Now that we generate the static-report locally for container mode, and because the bundle is not being created in current dir, the Linux container test will set the kantra dir to XDG_CONFIG_HOME/.kantra. 

Fixes #130 
Fixes #131 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved output normalization and code-snippet formatting for more consistent, readable analysis results.

* **Changes**
  * Removed the discovery-rules analysis block from cloud-readiness results.
  * Removed EJB XML–related tags from technology-usage summaries.

* **Chores**
  * Test workflow updated to create a config directory and symlink to ensure consistent CI environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->