### PR TITLE
Fix Linux container analysis static-report path

### DIFF
--- a/.github/actions/tests-linux-containers/action.yaml
+++ b/.github/actions/tests-linux-containers/action.yaml
@@ -34,6 +34,8 @@ runs:
   - name: Configure Test Environment
     shell: bash
     run: |
+      mkdir -p /home/runner/.config
+      ln -sf /home/runner/.kantra /home/runner/.config/.kantra
       chmod +x /home/runner/.kantra/kantra
       mkdir ${{ github.workspace }}/report
       # Temporary dirty workaround to execute container kantra (with run-local=false)


### PR DESCRIPTION
Now that we generate the static-report locally for container mode, and because the bundle is not being created in current dir, the Linux container test will set the kantra dir to `XDG_CONFIG_HOME/.kantra`.

Fixes https://github.com/konveyor/kantra-cli-tests/issues/130 

Relies on https://github.com/konveyor/kantra-cli-tests/pull/132 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test environment configuration for Linux container testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->